### PR TITLE
Ignore bond interfaces when creating mac_interface_map

### DIFF
--- a/ailib/__init__.py
+++ b/ailib/__init__.py
@@ -223,8 +223,9 @@ class AssistedClient(object):
             for entry in static_network_config:
                 mac_interface_map = []
                 for interface in entry['interfaces']:
-                    logical_nic_name, mac_address = interface['name'], interface['mac-address']
-                    mac_interface_map.append({"mac_address": mac_address, "logical_nic_name": logical_nic_name})
+                    if not 'bond' in interface['name']:                    
+                        logical_nic_name, mac_address = interface['name'], interface['mac-address']
+                        mac_interface_map.append({"mac_address": mac_address, "logical_nic_name": logical_nic_name})
                 new_entry = {'network_yaml': yaml.dump(entry), 'mac_interface_map': mac_interface_map}
                 final_network_config.append(models.HostStaticNetworkConfig(**new_entry))
             static_network_config = final_network_config


### PR DESCRIPTION
The bond interface takes the mac address of the primary link member interface and therefore does not have a mac address associated with it in the nmstate definition.